### PR TITLE
llvm-spirv v20.1.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "llvm-spirv" %}
-{% set version = "20.1.3" %}
+{% set version = "20.1.8" %}
 {% set llvm_version = ".".join(version.split(".")[:2]) %}
 {% set major = version.split('.')[0] %}
 # https://www.phoronix.com/news/LLVM-N-1-Stable-Versioning
@@ -16,7 +16,7 @@ package:
 
 source:
   url: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v{{ version.replace("_", "-") }}.tar.gz
-  sha256: 8e953931a09b0a4c2a77ddc8f1df4783571d8ffca9546150346c401573866062
+  sha256: 7b2f24440cb8b24f20d88e838c12fed486c5a00956a368b17b12b2c0431639c0
   patches:
     # https://github.com/llvm/llvm-project/issues/83802
     - patches/0001-Work-around-a-bug-in-the-llvm-config.patch  # [win]


### PR DESCRIPTION
Same as #50, but for v20; if it comes before #49, this avoids branch gymnastics (at least for now, upstream https://github.com/KhronosGroup/SPIRV-LLVM-Translator seems to support LLVM versions much longer than LLVM itself).