### PR TITLE
Update to 16.0.23

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "llvm-spirv" %}
-{% set version = "16.0.6" %}
+{% set version = "16.0.23" %}
 {% set llvm_version = ".".join(version.split(".")[:2]) %}
 {% set major = version.split('.')[0] %}
 # https://www.phoronix.com/news/LLVM-N-1-Stable-Versioning
@@ -16,7 +16,7 @@ package:
 
 source:
   url: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v{{ version.replace("_", "-") }}.tar.gz
-  sha256: 41aaf91bf95140fe3f755c32e7c009f090f206bea64f7a9a9cabb6de9e555909
+  sha256: c0fb4bd208e92c49f063ff71f8c7c2e1f0e877bd785e36268af3e24b5aea3635
   patches:
     # https://github.com/llvm/llvm-project/issues/83802
     - patches/0001-Work-around-a-bug-in-the-llvm-config.patch  # [win]


### PR DESCRIPTION
Intel seems to pin pretty hard on this version. working through uploading a few different ones.
<details><summary>Claude's draft</summary>

Bump SPIRV-LLVM-Translator from the v16.0.6 release tag (2024-10-30) to the v16.0.23 release (2026-03-17) on the llvm_release_160 branch.  This is the exact translator revision that Intel IGC v2.34.4 pins, and it carries the 97 backports merged since v16.0.6 -- notably the vload/vstore SPIR-V builtin signature fixes (#3478, #3480) and TranslatorOpts::setEmitFunctionPtrAddrSpace that the Intel Graphics Compiler 2.x line requires.

Builds against the current conda-forge spirv-headers (1.4.350.0) and spirv-tools (2026.2); verified locally with build-locally.py (all four outputs package and test successfully).

Note: v16.0.24/25 are newer but pull in SPV_INTEL_predicated_io / subgroup_buffer_prefetch changes that need a newer spirv-headers, so 16.0.23 is the right target for the current pinnings.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Resume this Claude session:
```
claude --resume 8959e104-fade-4e06-a903-ec84f609fa1c
```
</details>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
