### PR TITLE
Update to 16.0.25

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "llvm-spirv" %}
-{% set version = "16.0.23" %}
+{% set version = "16.0.25" %}
 {% set llvm_version = ".".join(version.split(".")[:2]) %}
 {% set major = version.split('.')[0] %}
 # https://www.phoronix.com/news/LLVM-N-1-Stable-Versioning
@@ -16,7 +16,7 @@ package:
 
 source:
   url: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v{{ version.replace("_", "-") }}.tar.gz
-  sha256: c0fb4bd208e92c49f063ff71f8c7c2e1f0e877bd785e36268af3e24b5aea3635
+  sha256: 5708672d3c7b28fe0d1ea58e56242917f2d3e96eb1809570a81bb60508afd3b7
   patches:
     # https://github.com/llvm/llvm-project/issues/83802
     - patches/0001-Work-around-a-bug-in-the-llvm-config.patch  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "llvm-spirv" %}
-{% set version = "16.0.6" %}
+{% set version = "16.0.23" %}
 {% set llvm_version = ".".join(version.split(".")[:2]) %}
 {% set major = version.split('.')[0] %}
 # https://www.phoronix.com/news/LLVM-N-1-Stable-Versioning
@@ -16,7 +16,7 @@ package:
 
 source:
   url: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v{{ version.replace("_", "-") }}.tar.gz
-  sha256: 41aaf91bf95140fe3f755c32e7c009f090f206bea64f7a9a9cabb6de9e555909
+  sha256: c0fb4bd208e92c49f063ff71f8c7c2e1f0e877bd785e36268af3e24b5aea3635
   patches:
     # https://github.com/llvm/llvm-project/issues/83802
     - patches/0001-Work-around-a-bug-in-the-llvm-config.patch  # [win]


### PR DESCRIPTION
Needs https://github.com/conda-forge/spirv-headers-feedstock/pull/37

<details><summary>Claude's draft</summary>

Bump SPIRV-LLVM-Translator to the v16.0.25 release (llvm_release_160 branch tip).

NOTE: 16.0.25 (vs 16.0.23) pulls in SPV_INTEL_predicated_io (#3729) and SPV_INTEL_subgroup_buffer_prefetch (#3690) which reference SPIR-V opcodes (OpPredicatedLoadINTEL/OpPredicatedStoreINTEL, ...) that are NOT in the current conda-forge spirv-headers (1.4.350.0).  This build therefore requires a spirv-headers bump first; otherwise the LLVMSPIRVLib compile fails with "'OpPredicatedLoadINTEL' was not declared in this scope".

For a translator that builds against today's pinnings, see the 16.0.23 branch (which is also the exact revision Intel IGC v2.34.4 pins).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Resume this Claude session:
```
claude --resume 8959e104-fade-4e06-a903-ec84f609fa1c
```
</details>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
